### PR TITLE
Make model configuration adapt to tokenizer metadata

### DIFF
--- a/resume_pretrain.py
+++ b/resume_pretrain.py
@@ -201,7 +201,10 @@ def resume_training(
         n_layer=16,
         n_head=16,
         n_embd=1296,
-        dropout=0.1
+        dropout=0.1,
+        pad_token_id=hf_tokenizer.pad_token_id,
+        bos_token_id=getattr(hf_tokenizer, "bos_token_id", None),
+        eos_token_id=hf_tokenizer.eos_token_id,
     )
     base_model = ArgonneModel(config)
     

--- a/training.py
+++ b/training.py
@@ -209,6 +209,9 @@ def train_model_parallel(
         attention_dropout=0.0,
         use_flash_attention=True,
         tie_word_embeddings=False,
+        pad_token_id=hf_tokenizer.pad_token_id,
+        bos_token_id=getattr(hf_tokenizer, "bos_token_id", None),
+        eos_token_id=hf_tokenizer.eos_token_id,
     )
     
     # Load non-streaming dataset once, outside the retry loop


### PR DESCRIPTION
## Summary
- allow ArgonneConfig to consume tokenizer-provided vocabulary and special token metadata
- expose embedding accessors/tie logic so the model can resize with tokenizer changes
- propagate tokenizer pad/bos/eos identifiers when building training configurations

## Testing
- python -m compileall model.py training.py resume_pretrain.py train_with_fsdp.py

------
https://chatgpt.com/codex/tasks/task_e_68e3d860e420832da05d1cd8b2c3b35d