### PR TITLE
Fix label device mismatch in cross entropy loss

### DIFF
--- a/model.py
+++ b/model.py
@@ -504,6 +504,8 @@ class ArgonneModel(PreTrainedModel):
         if labels is not None:
             shift_logits = logits[..., :-1, :].contiguous()
             shift_labels = labels[..., 1:].contiguous()
+            if shift_labels.device != shift_logits.device:
+                shift_labels = shift_labels.to(shift_logits.device)
             loss = F.cross_entropy(
                 shift_logits.view(-1, shift_logits.size(-1)),
                 shift_labels.view(-1),


### PR DESCRIPTION
## Summary
- ensure the shifted labels are moved to the logits device before computing cross entropy loss to avoid device mismatch errors during pipeline parallel training

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e41d83815c832d97639d2d665f76f4