### PR TITLE
Fix device mismatch during text generation

### DIFF
--- a/model.py
+++ b/model.py
@@ -659,7 +659,7 @@ class ArgonneModel(PreTrainedModel):
             else:
                 next_token = torch.argmax(logits, dim=-1, keepdim=True)
 
-            input_ids = torch.cat([input_ids, next_token], dim=-1)
+            input_ids = torch.cat([input_ids, next_token.to(input_ids.device)], dim=-1)
             if input_ids.shape[1] >= max_length:
                 break
         return input_ids.to(device)


### PR DESCRIPTION
## Summary
- ensure the autoregressive generation loop moves the sampled token back onto the input tensor's device before concatenation
- prevent cross-device concatenation errors when running the multi-GPU pipeline during training

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e53b8edd60832d92265e7f8be8844a