### PR TITLE
Fix attention reshape to handle non-divisible hidden size

### DIFF
--- a/model.py
+++ b/model.py
@@ -267,7 +267,11 @@ class GroupedQueryAttention(nn.Module):
             attn_weights = F.dropout(attn_weights, p=self.attention_dropout, training=self.training)
             attn_output = torch.matmul(attn_weights, value)
 
-        attn_output = attn_output.transpose(1, 2).contiguous().view(bsz, seqlen, self.hidden_size)
+        attn_output = (
+            attn_output.transpose(1, 2)
+            .contiguous()
+            .view(bsz, seqlen, self.num_heads * self.head_dim)
+        )
         return self.o_proj(attn_output)
 
 


### PR DESCRIPTION
## Summary
- avoid reshaping attention output to a mismatched hidden size by using the projected dimensionality

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e56757a050832db1f588b0cce55116